### PR TITLE
Add interval start timestamp

### DIFF
--- a/api/models/Interval.js
+++ b/api/models/Interval.js
@@ -29,6 +29,10 @@ const intervalSchema = new Schema({
     type: Number,
     required: true
   },
+  intervalStartAt: {
+    type: Date,
+    required: true
+  },
   updatedAt: {
     type: Date,
     default: Date.now,

--- a/api/utils/utils_function.js
+++ b/api/utils/utils_function.js
@@ -1091,6 +1091,7 @@ const CreateIntervalMessageOperation = (student_id, msg1, msg2) => {
     message_2_id: msg2._id,
     interval_type: 'communication',
     interval: intervalValue,
+    intervalStartAt: msg1.createdAt,
     updatedAt: new Date()
   };
 
@@ -1174,6 +1175,7 @@ const CreateIntervalOperation = (thread, msg1, msg2) => {
     message_2_id: msg2._id,
     interval_type: thread.file_type,
     interval: intervalValue,
+    intervalStartAt: msg1.createdAt,
     updatedAt: new Date()
   };
 


### PR DESCRIPTION
Add `intervalStartAt` for chronological sorting of statistics. Required for third layer of response time dashboard (avoid additional lookup effort during runtime)

responseTime and interval collections needs to be dropped and recreated. (tested in dev)